### PR TITLE
Endpoints de private lesson (crear, get all y por id)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -7,6 +7,8 @@ from app.schemas.user import UserCreate, UserLogin, UserOut
 from app.crud.user import create_user, get_user_by_email
 from app.auth.auth_handler import verify_password, create_access_token
 from app.auth.auth_bearer import JWTBearer
+from app.crud.private_lesson import get_all_private_lessons, get_private_lesson_by_id, create_private_lesson
+from app.schemas.private_lesson import PrivateLessonOut, PrivateLessonCreate
 
 from app.api.chat import manager  # <-- nuestro chat manager
 
@@ -59,3 +61,18 @@ async def websocket_chat(websocket: WebSocket, username: str):
             "system": True,
             "message": f"❌ {left} ha salido del chat"
         })
+
+######## Private Lessons Routes ########
+@router.get("/private-lessons", response_model=List[PrivateLessonOut])
+async def read_all_private_lessons(db: AsyncSession = Depends(get_db)):
+    return await get_all_private_lessons(db)
+
+@router.get("/private-lessons/{lesson_id}", response_model=PrivateLessonOut)
+async def read_private_lesson_by_id(lesson_id: int, db: AsyncSession = Depends(get_db)):
+    lesson = await get_private_lesson_by_id(db, lesson_id)
+    if not lesson:
+        raise HTTPException(status_code=404, detail="Private lesson not found")
+    return lesson
+@router.post("/private-lessons", response_model=PrivateLessonOut, dependencies=[Depends(JWTBearer())])
+async def create_lesson(lesson: PrivateLessonCreate, db: AsyncSession = Depends(get_db)):
+    return await create_private_lesson(db, lesson)

--- a/app/crud/private_lesson.py
+++ b/app/crud/private_lesson.py
@@ -1,0 +1,18 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from app.models.private_lesson import PrivateLesson
+
+async def get_all_private_lessons(db: AsyncSession):
+    result = await db.execute(select(PrivateLesson))
+    return result.scalars().all()
+
+async def get_private_lesson_by_id(db: AsyncSession, lesson_id: int):
+    result = await db.execute(select(PrivateLesson).where(PrivateLesson.id == lesson_id))
+    return result.scalar_one_or_none()
+
+async def create_private_lesson(db: AsyncSession, lesson: PrivateLessonCreate):
+    db_lesson = PrivateLesson(**lesson.dict())
+    db.add(db_lesson)
+    await db.commit()
+    await db.refresh(db_lesson)
+    return db_lesson

--- a/app/schemas/private_lesson.py
+++ b/app/schemas/private_lesson.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+class PrivateLessonBase(BaseModel):
+    tutor_id: int
+    course_id: int
+    start_time: datetime
+    end_time: datetime
+    price: int
+
+class PrivateLessonOut(PrivateLessonBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class PrivateLessonCreate(PrivateLessonBase):
+    pass


### PR DESCRIPTION
Inclusión de enpoints relacionados a todo aquel endpoint sobre Clases Privadas (PrivateLesson), incluye:

1. Crear Clases
2. Obtener listado de todas las clases
3. Obtener clases según su id en la Base de Datos

Trabajo realizado por @Jpobletel , y revisado por @SCarcG1 

Issues relacionadas
- #35 